### PR TITLE
Fix IRB integration

### DIFF
--- a/bin/console
+++ b/bin/console
@@ -2,7 +2,7 @@
 # frozen_string_literal: true
 
 require "bundler/setup"
-require "tracer/irb"
+require "tracer"
 
 # You can add fixtures and/or initialization code here to make experimenting
 # with your gem easier. You can also use a different console, if you like.

--- a/lib/tracer/irb.rb
+++ b/lib/tracer/irb.rb
@@ -1,4 +1,3 @@
-require_relative "../tracer"
 require "irb/cmd/nop"
 require "irb"
 

--- a/lib/tracer/irb.rb
+++ b/lib/tracer/irb.rb
@@ -1,6 +1,15 @@
 require "irb/cmd/nop"
 require "irb"
 
+if Gem::Version.new(IRB::VERSION) < Gem::Version.new("1.6.0")
+  warn <<~MSG
+    Your version of IRB is too old so Tracer cannot register its commands.
+    Please upgrade IRB by adding `gem "irb", "~> 1.6.0"` to your Gemfile.
+  MSG
+
+  return
+end
+
 module Tracer
   def self.register_irb_commands
     ec = IRB::ExtendCommandBundle.instance_variable_get(:@EXTEND_COMMANDS)


### PR DESCRIPTION
1. Some of my changes in #9 was not necessary and accidentally caused circular require issue. So I'm fixing that in this PR
2. If the users' IRB version is not suitable for registering commands, the integration should print a warning and return early.