### PR TITLE
Add IvarTracer for tracing ivar changes

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -9,3 +9,4 @@ gem "rake", "~> 13.0"
 gem "irb"
 
 gem "test-unit", "~> 3.0"
+gem "syntax_tree"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -10,9 +10,12 @@ GEM
     irb (1.6.2)
       reline (>= 0.3.0)
     power_assert (2.0.2)
+    prettier_print (1.2.1)
     rake (13.0.6)
     reline (0.3.2)
       io-console (~> 0.5)
+    syntax_tree (6.1.1)
+      prettier_print (>= 1.2.0)
     test-unit (3.5.5)
       power_assert
 
@@ -24,6 +27,7 @@ PLATFORMS
 DEPENDENCIES
   irb
   rake (~> 13.0)
+  syntax_tree
   test-unit (~> 3.0)
   tracer!
 

--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ The `tracer` gem provides helpful tracing utilities to help users observe their 
 The currently supported tracers are:
 
 - [`ObjectTracer`](#objecttracer)
+- [`IvarTracer`](#ivartracer)
 - [`CallTracer`](#calltracer)
 - [`ExceptionTracer`](#exceptiontracer)
 - [`LineTracer`](#linetracer)
@@ -101,6 +102,30 @@ end
  #depth:3  #<User:0x000000010696cad8 @name="John"> receives #name (User#name) at test.rb:14:in `block in <main>'
  #depth:3  #<User:0x000000010696cad8 @name="John"> is used as a parameter user of Object#authorized? at test.rb:15:in `block in <main>'
  #depth:4  #<User:0x000000010696cad8 @name="John"> receives #name (User#name) at test.rb:8:in `authorized?'
+```
+
+#### IvarTracer
+
+> **Note**
+> Ruby 3.0 and below's accessor calls don't trigger TracePoint properly so the result may be inaccurate with those versions.
+
+```rb
+require "tracer"
+
+class Cat
+  attr_accessor :name
+end
+
+cat = Cat.new
+
+tracer = IvarTracer.new(cat, :@name)
+tracer.start do
+  cat.name = "Kitty"
+  cat.instance_variable_set(:@name, "Ketty")
+end
+
+#depth:3 Cat#name= sets @name = "Kitty" at test.rb:11
+#depth:3 Kernel#instance_variable_set sets @name = "Ketty" at test.rb:12
 ```
 
 #### ExceptionTracer

--- a/lib/tracer.rb
+++ b/lib/tracer.rb
@@ -5,6 +5,7 @@ require_relative "tracer/line_tracer"
 require_relative "tracer/call_tracer"
 require_relative "tracer/exception_tracer"
 require_relative "tracer/object_tracer"
+require_relative "tracer/ivar_tracer"
 
 module Tracer
   module Helper

--- a/lib/tracer/base.rb
+++ b/lib/tracer/base.rb
@@ -10,6 +10,7 @@ module Tracer
     M_INSPECT = Object.instance_method(:inspect)
     M_CLASS = Object.instance_method(:class)
     M_IS_A = Object.instance_method(:is_a?)
+    M_INSTANCE_VARIABLE_GET = Object.instance_method(:instance_variable_get)
     HOME = ENV["HOME"] ? (ENV["HOME"] + "/") : nil
 
     include Color

--- a/lib/tracer/ivar_tracer.rb
+++ b/lib/tracer/ivar_tracer.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+require_relative "base"
+
+class IvarTracer < Tracer::Base
+  def initialize(target, var_name, **kw)
+    @target = target
+    @var_name = var_name
+    @original_value = M_INSTANCE_VARIABLE_GET.bind_call(target, var_name)
+    super(**kw)
+  end
+
+  def key
+    [@type, @target, @var_name, @pattern, @into].freeze
+  end
+
+  def description
+    "for #{@var_name} of #{@target} #{super}"
+  end
+
+  def setup_tp
+    TracePoint.new(:a_return) do |tp|
+      next if skip?(tp)
+
+      if tp.self == @target &&
+           value = M_INSTANCE_VARIABLE_GET.bind_call(@target, @var_name)
+        if tp.event == :c_return
+          location = nil
+        else
+          location = caller_locations(2, 1).first.to_s
+          next if location.match?(DIR) || location.match?(/<internal:/)
+        end
+
+        depth = caller.size
+        call_identifier_str = (tp.defined_class ? minfo(tp) : "block")
+        call_identifier_str = colorize_blue(call_identifier_str)
+        depth += 1 if tp.event == :c_return
+        value = safe_inspect(value)
+
+        if value != @original_value
+          out tp,
+              "#{call_identifier_str} sets #{colorize_cyan(@var_name)} = #{colorize_magenta(value)}",
+              depth: depth - 2 - @depth_offset,
+              location: location
+        end
+      end
+    end
+  end
+end

--- a/test/tracer/ivar_tracer_test.rb
+++ b/test/tracer/ivar_tracer_test.rb
@@ -1,0 +1,111 @@
+require_relative "../test_helper"
+
+module Tracer
+  class IvarTracerTest < TestCase
+    include ActivationTests
+
+    def build_tracer
+      stub_object = Object.new
+      IvarTracer.new(stub_object, :@foo, output: @output)
+    end
+  end
+
+  class IvarTracerIntegrationTest < IntegrationTestCase
+    def test_ivar_tracer_traces_attr_accessor_changes
+      # Ruby 3.0 and below's attr_accessor calls don't trigger TracePoint properly
+      omit if RUBY_VERSION < "3.1"
+
+      file = write_file("foo.rb", <<~RUBY)
+        class Foo
+          attr_accessor :bar
+        end
+
+        obj = Foo.new
+
+        IvarTracer.new(obj, :@bar).start
+
+        obj.bar = 100
+      RUBY
+
+      out, err = execute_file(file)
+
+      assert_empty(err)
+      assert_traces(
+        [%r{^#depth:0 Foo#bar= sets @bar = 100 at .*/foo\.rb:9}],
+        out
+      )
+    end
+
+    def test_ivar_tracer_traces_method_changes
+      file = write_file("foo.rb", <<~RUBY)
+        class Foo
+          def bar=(value)
+            @bar = value
+          end
+        end
+
+        obj = Foo.new
+
+        IvarTracer.new(obj, :@bar).start
+
+        obj.bar = 100
+      RUBY
+
+      out, err = execute_file(file)
+
+      assert_empty(err)
+      assert_traces(
+        [%r{^#depth:0 Foo#bar= sets @bar = 100 at .*/foo\.rb:11}],
+        out
+      )
+    end
+
+    def test_ivar_tracer_with_header
+      file = write_file("foo.rb", <<~RUBY)
+        class Foo
+          def bar=(value)
+            @bar = value
+          end
+        end
+
+        obj = Foo.new
+
+        IvarTracer.new(obj, :@bar, header: "trace-foo@bar").start
+
+        obj.bar = 100
+      RUBY
+
+      out, err = execute_file(file)
+
+      assert_empty(err)
+      assert_traces(
+        [%r{^trace-foo@bar #depth:0 Foo#bar= sets @bar = 100 at .*/foo\.rb:11}],
+        out
+      )
+    end
+
+    def test_ivar_tracer_works_with_basic_object
+      file = write_file("foo.rb", <<~RUBY)
+        class Foo < BasicObject
+          def bar=(value)
+            @bar = value
+          end
+        end
+
+        obj = Foo.new
+
+        IvarTracer.new(obj, :@bar).start
+
+        obj.bar = 100
+      RUBY
+
+      out, err = execute_file(file)
+
+      assert_empty(err)
+      assert_traces(
+        [%r{^#depth:0 Foo#bar= sets @bar = 100 at .*/foo\.rb:11}],
+        out
+      )
+    end
+  end
+end


### PR DESCRIPTION
This idea was proposed by and implemented with @KaanOzkan.

`IvarTracer` will print traces when the target object' target attribute is being reassigned.

```rb
require "tracer"

class Cat
  attr_accessor :name
end

cat = Cat.new

tracer = IvarTracer.new(cat, :@name)
tracer.start do
  cat.name = "Kitty" #=> #depth:3 Cat#name= sets @name = "Kitty" at test.rb:11
  cat.instance_variable_set(:@name, "Ketty") #=> #depth:3 Kernel#instance_variable_set sets @name = "Ketty" at test.rb:12
end
```