### PR TITLE
Trace exception rescue

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,7 +139,8 @@ rescue StandardError
   nil
 end
 
- #depth:1  #<RuntimeError: boom> at test.rb:4
+#depth:0  #<RuntimeError: boom> raised at test.rb:4
+#depth:1  #<RuntimeError: boom> rescued at test.rb:6
 ```
 
 #### CallTracer

--- a/test/tracer/helper_test.rb
+++ b/test/tracer/helper_test.rb
@@ -13,8 +13,16 @@ module Tracer
 
       out, err = execute_file(file)
 
+      expected_traces = [
+        /^#depth:1  #<RuntimeError: boom> raised at .*foo.rb:4/
+      ]
+
+      if RUBY_VERSION >= "3.3.0"
+        expected_traces << /^#depth:2  #<RuntimeError: boom> rescued at .*foo.rb:4/
+      end
+
       assert_empty(err)
-      assert_traces([/#depth:1  #<RuntimeError: boom> at .*foo.rb:4/], out)
+      assert_traces(expected_traces, out)
     end
 
     def test_trace_call


### PR DESCRIPTION
This feature is only activated in Ruby 3.3 and later. It allows the tracer to print trace when exceptions are rescued.